### PR TITLE
Broken link in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -170,7 +170,7 @@ Parabéns, você contribuiu com êxito para o projeto.
 
 ### <a name="markdown"></a>Markdown
 
-Todos os artigos neste repositório usam Markdown. Uma introdução completa (e lista de todos os a sintaxe) podem ser encontradas no [Daring bola de fogo - redução].
+Todos os artigos neste repositório usam Markdown. Uma introdução completa (e lista de todos os a sintaxe) podem ser encontradas no [Daring Fireball - redução].
  
 ## <a name="faq"></a>Perguntas frequentes
 
@@ -199,11 +199,11 @@ As solicitações pull geralmente são analisadas dentro de 10 dias úteis.
 
 ## <a name="more-resources"></a>Mais recursos
 
-* Para saber mais sobre redução, vá para o site do criador redução [Daring bola de fogo].
-* Para saber mais sobre como usar gito e GitHub, confira-a [GitHub ajuda].
+* Para saber mais sobre redução, vá para o site do criador redução [Daring Fireball].
+* Para saber mais sobre como usar gito e GitHub, confira-a [ajuda do GitHub].
 
 [GitHub Home]: http://github.com
 [Ajuda do GitHub]: http://help.github.com/
 [Configurar gito]: https://help.github.com/articles/set-up-git/
-[Daring bola de fogo - redução]: http://daringfireball.net/projects/markdown/
+[Daring Fireball - redução]: http://daringfireball.net/projects/markdown/
 [Daring Fireball]: http://daringfireball.net/

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Eles são importantes para nós.
 ## <a name="microsoft-open-source-code-of-conduct"></a>Código de conduta do Código Aberto da Microsoft
 
 Este projeto adotou o [Código de Conduta de Software Livre da Microsoft](https://opensource.microsoft.com/codeofconduct/).
-Para obter mais informações, consulte o [Código de conduzir FAQ](https://opensource.microsoft.com/codeofconduct/faq/)ou entre em contato com [opencode@microsoft.com](mailto:opencode@microsoft.com) com quaisquer comentários ou perguntas adicionais.
+Para obter mais informações, consulte o [Código de conduzir FAQ](https://opensource.microsoft.com/codeofconduct/faq/) ou entre em contato com [opencode@microsoft.com](mailto:opencode@microsoft.com) com quaisquer comentários ou perguntas adicionais.
 


### PR DESCRIPTION
There are two broken links in the section "[Mais recursos](https://github.com/IgorRozani/office-js-docs-pr.pt-br/blob/live/Contributing.md#mais-recursos)" in Contributing.md.

![image](https://user-images.githubusercontent.com/802968/47241467-26a0f900-d3c2-11e8-888e-c6971cab57be.png)

And i fixed a wrong translation of Daring Fireball.
